### PR TITLE
Fix Project Name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "gradle-dependency-resolution-plugin "
+rootProject.name = "gradle-dependency-resolution-plugin"
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
Remove whitespace from project name:

IllegalArgumentException: Cannot publish artifacts as artifact ID 'gradle-dependency-resolution-plugin ' is invalid.
