### PR TITLE
Fix auth via header

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,12 @@ plugins {
 
 # Release History
 
+## 1.0.1 fix auth via header
+
+Fixes the authentication via header to solve the error:
+
+>Cannot create a Authentication named 'header' because this container does not support creating
+>elements by name alone. Please specify which subtype of Authentication to create. Known subtypes
+>are: AwsImAuthentication, BasicAuthentication, DigestAuthentication, HttpHeaderAuthentication
+
 ## 1.0.0 initial release

--- a/src/main/kotlin/com/supcis/infrastructure/gradle/Configuration.kt
+++ b/src/main/kotlin/com/supcis/infrastructure/gradle/Configuration.kt
@@ -3,6 +3,7 @@ package com.supcis.infrastructure.gradle
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.repositories.AuthenticationSupported
 import org.gradle.api.credentials.HttpHeaderCredentials
+import org.gradle.authentication.http.HttpHeaderAuthentication
 import org.gradle.internal.jvm.inspection.JvmVendor.KnownJvmVendor
 
 object Configuration {
@@ -39,7 +40,7 @@ fun AuthenticationSupported.setAuth() {
             it.value = "Bearer " + Configuration.password
         }
         authentication {
-            it.create("header")
+            it.create("header", HttpHeaderAuthentication::class.java)
         }
     } else {
         credentials {


### PR DESCRIPTION
The type of the Authentication-Header was not specified which lead to the following error:

> Cannot create a Authentication named 'header' because this container does not support creating elements by name alone. Please specify which subtype of Authentication to create. Known subtypes are: AwsImAuthentication, BasicAuthentication, DigestAuthentication, HttpHeaderAuthentication

This error only occurs when the env `MAVEN_AUTHENTICATION` is set to `HttpHeader`.
