### PR TITLE
SUPS-1333: Add Gradle Remote Build Cache Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,35 @@ plugins {
 }
 ```
 
+### Remote Build Cache Plugin
+
+The Remote Build Cache Plugin adds a remote build cache to the gradle configuration.
+The cache is configured via environment variables:
+- GRADLE_REMOTE_BUILD_CACHE_URL: the base URL for the remote build cache (optional)
+- PUSH_TO_REMOTE_BUILD_CACHE: boolean value whether to push to the remote build cache
+  or to use it only for pulling. (optional, default: false)
+- MAVEN_USER: the username for the maven repository (optional)
+- MAVEN_PASSWORD: the password for the maven repository (optional)
+
+No remote cache is added if no `GRADLE_REMOTE_BUILD_CACHE_URL` is set.
+
+You still need to activate the build cache in your project, see
+[gradle user guide](https://docs.gradle.org/current/userguide/build_cache.html).
+
+
+#### How To Use
+
+Add the following lines to the `settings.gradle.kts`:
+
+```settings.gralde.kts
+plugins {
+    id("com.supcis.remote-build-cache") version "1.0.1"
+}
+```
+
 ### Combined Resolution Plugin
 
-The Combined Resolution Plugin is a convenience plugin that applies all the three plugins above.
+The Combined Resolution Plugin is a convenience plugin that applies all the four plugins above.
 
 #### How To Use
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The JDK is expected to be in the form of a maven coordinate:
 
 Add the following lines to the `settings.gradle.kts`:
 
-```settings.gralde.kts
+```settings.gradle.kts
 plugins {
     id("com.supcis.java-toolchain-resolver") version "1.1.0"
 }
@@ -42,7 +42,7 @@ that is configured via environment variables:
 
 Add the following lines to the `settings.gradle.kts`:
 
-```settings.gralde.kts
+```settings.gradle.kts
 plugins {
     id("com.supcis.dependency-resolution") version "1.1.0"
 }
@@ -60,7 +60,7 @@ that is configured via environment variables:
 
 Add the following lines to the `settings.gradle.kts`:
 
-```settings.gralde.kts
+```settings.gradle.kts
 plugins {
     id("com.supcis.plugin-resolution") version "1.1.0"
 }
@@ -86,7 +86,7 @@ You still need to activate the build cache in your project, see
 
 Add the following lines to the `settings.gradle.kts`:
 
-```settings.gralde.kts
+```settings.gradle.kts
 plugins {
     id("com.supcis.remote-build-cache") version "1.1.0"
 }
@@ -100,7 +100,7 @@ The Combined Resolution Plugin is a convenience plugin that applies all the four
 
 Add the following lines to the `settings.gradle.kts`:
 
-```settings.gralde.kts
+```settings.gradle.kts
 plugins {
     id("com.supcis.resolution") version "1.1.0"
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the following lines to the `settings.gradle.kts`:
 
 ```settings.gralde.kts
 plugins {
-    id("com.supcis.java-toolchain-resolver") version "1.0.1"
+    id("com.supcis.java-toolchain-resolver") version "1.1.0"
 }
 ```
 
@@ -44,7 +44,7 @@ Add the following lines to the `settings.gradle.kts`:
 
 ```settings.gralde.kts
 plugins {
-    id("com.supcis.dependency-resolution") version "1.0.1"
+    id("com.supcis.dependency-resolution") version "1.1.0"
 }
 ```
 
@@ -62,7 +62,7 @@ Add the following lines to the `settings.gradle.kts`:
 
 ```settings.gralde.kts
 plugins {
-    id("com.supcis.plugin-resolution") version "1.0.1"
+    id("com.supcis.plugin-resolution") version "1.1.0"
 }
 ```
 
@@ -88,7 +88,7 @@ Add the following lines to the `settings.gradle.kts`:
 
 ```settings.gralde.kts
 plugins {
-    id("com.supcis.remote-build-cache") version "1.0.1"
+    id("com.supcis.remote-build-cache") version "1.1.0"
 }
 ```
 
@@ -102,11 +102,15 @@ Add the following lines to the `settings.gradle.kts`:
 
 ```settings.gralde.kts
 plugins {
-    id("com.supcis.resolution") version "1.0.1"
+    id("com.supcis.resolution") version "1.1.0"
 }
 ```
 
 # Release History
+
+## 1.1.0 add remote build cache plugin
+
+See description above
 
 ## 1.0.1 fix auth via header
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,21 @@ gradlePlugin {
         """.trimIndent()
         tags.add("plugin resolution")
     }
+    plugins.create("RemoteBuildCachePlugin") {
+        displayName = "Remote Build Cache Plugin"
+        id = "com.supcis.remote-build-cache"
+        implementationClass = "com.supcis.infrastructure.gradle.RemoteBuildCachePlugin"
+        description = """
+            Adds a remote build cache that is configured via environment variables:
+            - GRADLE_REMOTE_BUILD_CACHE_URL: the base URL for the remote build cache
+            - PUSH_TO_REMOTE_BUILD_CACHE: boolean value whether to push to the remote build cache
+              or to use it only for pulling. (optional, default: false)
+            - MAVEN_USER: the username for the maven repository (optional)
+            - MAVEN_PASSWORD: the password for the maven repository (optional)
+            No remote cache is added if no GRADLE_REMOTE_BUILD_CACHE_URL is set.
+        """.trimIndent()
+        tags.add("remote build cache")
+    }
     plugins.create("CombinedResolutionPlugin") {
         displayName = "Combined Resolution Plugin"
         id = "com.supcis.resolution"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 group = "com.supcis.plugins.gradle"
 
-version = "1.0.1"
+version = "1.1.0"
 
 plugins {
     `java-gradle-plugin`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -88,9 +88,14 @@ gradlePlugin {
         id = "com.supcis.resolution"
         implementationClass = "com.supcis.infrastructure.gradle.CombinedResolutionPlugin"
         description = """
-            Applies all three resolution plugins: JavaToolchainResolver, DependencyResolutionPlugin
-            and PluginResolutionPlugin. This is just for convenience.
+            Applies all four resolution plugins: JavaToolchainResolver, DependencyResolutionPlugin,
+            PluginResolutionPlugin and RemoteBuildCachePlugin. This is just for convenience.
         """.trimIndent()
-        tags.addAll("toolchain resolver", "dependency resolution", "plugin resolution")
+        tags.addAll(
+            "toolchain resolver",
+            "dependency resolution",
+            "plugin resolution",
+            "remote build cache",
+        )
     }
 }

--- a/src/main/kotlin/com/supcis/infrastructure/gradle/CombinedResolutionPlugin.kt
+++ b/src/main/kotlin/com/supcis/infrastructure/gradle/CombinedResolutionPlugin.kt
@@ -13,5 +13,6 @@ abstract class CombinedResolutionPlugin : Plugin<Settings> {
         settings.plugins.apply("com.supcis.plugin-resolution")
         settings.plugins.apply("com.supcis.dependency-resolution")
         settings.plugins.apply("com.supcis.java-toolchain-resolver")
+        settings.plugins.apply("com.supcis.remote-build-cache")
     }
 }

--- a/src/main/kotlin/com/supcis/infrastructure/gradle/Configuration.kt
+++ b/src/main/kotlin/com/supcis/infrastructure/gradle/Configuration.kt
@@ -13,6 +13,8 @@ object Configuration {
     private val MAVEN_DOWNLOAD_URL = "MAVEN_DOWNLOAD_URL"
     private val MAVEN_USER = "MAVEN_USER"
     private val MAVEN_PASSWORD = "MAVEN_PASSWORD"
+    private val GRADLE_REMOTE_BUILD_CACHE_URL = "GRADLE_REMOTE_BUILD_CACHE_URL"
+    private val IS_PUSH_TO_REMOTE_BUILD_CACHE = "PUSH_TO_REMOTE_BUILD_CACHE"
 
     internal val DEFAULT_JDK_VENDOR = KnownJvmVendor.ADOPTIUM
 
@@ -31,6 +33,14 @@ object Configuration {
 
     val password: String? by lazy {
         System.getenv(MAVEN_PASSWORD) ?: "x"
+    }
+
+    val remoteBuildCacheUrl: String? by lazy {
+        System.getenv(GRADLE_REMOTE_BUILD_CACHE_URL)
+    }
+
+    val isPushToRemoteBuildCache: Boolean by lazy {
+        System.getenv(IS_PUSH_TO_REMOTE_BUILD_CACHE).toBoolean()
     }
 }
 

--- a/src/main/kotlin/com/supcis/infrastructure/gradle/Configuration.kt
+++ b/src/main/kotlin/com/supcis/infrastructure/gradle/Configuration.kt
@@ -3,6 +3,7 @@ package com.supcis.infrastructure.gradle
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.repositories.AuthenticationSupported
 import org.gradle.api.credentials.HttpHeaderCredentials
+import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.authentication.http.HttpHeaderAuthentication
 import org.gradle.internal.jvm.inspection.JvmVendor.KnownJvmVendor
 
@@ -36,16 +37,24 @@ object Configuration {
 fun AuthenticationSupported.setAuth() {
     if (Configuration.isAuthTypeHeader) {
         credentials(HttpHeaderCredentials::class.java) {
-            it.name = "Authorization"
-            it.value = "Bearer " + Configuration.password
+            it.setAuth()
         }
         authentication {
             it.create("header", HttpHeaderAuthentication::class.java)
         }
     } else {
         credentials {
-            it.username = Configuration.username
-            it.password = Configuration.password
+            it.setAuth()
         }
     }
+}
+
+fun HttpHeaderCredentials.setAuth() {
+    name = "Authorization"
+    value = "Bearer " + Configuration.password
+}
+
+fun PasswordCredentials.setAuth() {
+    username = Configuration.username
+    password = Configuration.password
 }

--- a/src/main/kotlin/com/supcis/infrastructure/gradle/Configuration.kt
+++ b/src/main/kotlin/com/supcis/infrastructure/gradle/Configuration.kt
@@ -8,13 +8,13 @@ import org.gradle.authentication.http.HttpHeaderAuthentication
 import org.gradle.internal.jvm.inspection.JvmVendor.KnownJvmVendor
 
 object Configuration {
-    private val MAVEN_AUTHENTICATION = "MAVEN_AUTHENTICATION"
-    private val MAVEN_AUTHENTICATION_VIA_HEADER = "HttpHeader"
-    private val MAVEN_DOWNLOAD_URL = "MAVEN_DOWNLOAD_URL"
-    private val MAVEN_USER = "MAVEN_USER"
-    private val MAVEN_PASSWORD = "MAVEN_PASSWORD"
-    private val GRADLE_REMOTE_BUILD_CACHE_URL = "GRADLE_REMOTE_BUILD_CACHE_URL"
-    private val IS_PUSH_TO_REMOTE_BUILD_CACHE = "PUSH_TO_REMOTE_BUILD_CACHE"
+    private const val MAVEN_AUTHENTICATION = "MAVEN_AUTHENTICATION"
+    private const val MAVEN_AUTHENTICATION_VIA_HEADER = "HttpHeader"
+    private const val MAVEN_DOWNLOAD_URL = "MAVEN_DOWNLOAD_URL"
+    private const val MAVEN_USER = "MAVEN_USER"
+    private const val MAVEN_PASSWORD = "MAVEN_PASSWORD"
+    private const val GRADLE_REMOTE_BUILD_CACHE_URL = "GRADLE_REMOTE_BUILD_CACHE_URL"
+    private const val IS_PUSH_TO_REMOTE_BUILD_CACHE = "PUSH_TO_REMOTE_BUILD_CACHE"
 
     internal val DEFAULT_JDK_VENDOR = KnownJvmVendor.ADOPTIUM
 

--- a/src/main/kotlin/com/supcis/infrastructure/gradle/RemoteBuildCachePlugin.kt
+++ b/src/main/kotlin/com/supcis/infrastructure/gradle/RemoteBuildCachePlugin.kt
@@ -1,0 +1,25 @@
+package com.supcis.infrastructure.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+import java.net.URI
+import org.gradle.caching.http.HttpBuildCache
+
+/**
+ * This Plugin adds a remote build cache that is configured via
+ * environment variables, see [Configuration].
+ */
+abstract class RemoteBuildCachePlugin : Plugin<Settings> {
+
+    override fun apply(settings: Settings) {
+        val url = Configuration.remoteBuildCacheUrl ?: return
+
+        settings.buildCache {
+            it.remote(HttpBuildCache::class.java) {
+                it.url = URI(url)
+                it.credentials.setAuth()
+                it.isPush = Configuration.isPushToRemoteBuildCache
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a Plugin that configures a gradle remote build cache.

The cache is only enabled when the env GRADLE_REMOTE_BUILD_CACHE_URL is set.

In addition the gradle build caching must be enabled.