### PR TITLE
Explicitly reject blank strings for Maven user and password

### DIFF
--- a/src/main/kotlin/com/supcis/infrastructure/gradle/Configuration.kt
+++ b/src/main/kotlin/com/supcis/infrastructure/gradle/Configuration.kt
@@ -28,12 +28,12 @@ object Configuration {
                " - Consult https://github.com/Element-Logic/gradle-dependency-resolution-plugin/blob/main/TROUBLESHOOTING.md for help")
     }
 
-    val username: String? by lazy {
-        System.getenv(MAVEN_USER) ?: "x"
+    val username: String by lazy {
+        System.getenv(MAVEN_USER)?.takeIf { it.isNotBlank() } ?: "x"
     }
 
-    val password: String? by lazy {
-        System.getenv(MAVEN_PASSWORD) ?: "x"
+    val password: String by lazy {
+        System.getenv(MAVEN_PASSWORD)?.takeIf { it.isNotBlank() } ?: "x"
     }
 
     val remoteBuildCacheUrl: String? by lazy {


### PR DESCRIPTION
This PR adds functionality that was implemented in other repositories and were migrated to the `com.supcis.resolution` plugin. This change intends to offer parity with their previous implementation while making wrong environment variable configurations more visible for all other consumers.